### PR TITLE
Fix some clients not passing valid access token

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -56,7 +56,8 @@ func main() {
 		}
 
 		// Step 4: Use the access token, here we use it to get the logged in user's info.
-		res, err := conf.Client(oauth2.NoContext, token).Get("https://discordapp.com/api/v6/users/@me")
+		// Not specifying API version seems to fix issues for some token issues.
+		res, err := conf.Client(oauth2.NoContext, token).Get("https://discordapp.com/api/users/@me")
 
 		if err != nil || res.StatusCode != 200 {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/example/main.go
+++ b/example/main.go
@@ -56,7 +56,6 @@ func main() {
 		}
 
 		// Step 4: Use the access token, here we use it to get the logged in user's info.
-		// Not specifying API version seems to fix issues for some token issues.
 		res, err := conf.Client(oauth2.NoContext, token).Get("https://discordapp.com/api/users/@me")
 
 		if err != nil || res.StatusCode != 200 {


### PR DESCRIPTION
## Issue Description
Some users, when going through the OAuth2 flow, were getting hit with Internal Server Errors. This was due to an invalid code being passed.

## How was the situation resolved?
Removing the API version from the access request seemed to cause this issue to disappear. This is best practice, anyways, as this will default to whichever API Discord deems suitable at the time.

## Testing?
I'm testing this on a pre-production website using the Fiber framework and this library. I've tested this fix with several people and it seems to be that this is the definitive fix.

If you need more information, please let me know.