### PR TITLE
Remove deprecared OAuth2 Context

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"github.com/pollen5/discord-oauth2"
 	"golang.org/x/oauth2"
 	"io/ioutil"
@@ -47,7 +48,7 @@ func main() {
 		}
 		// Step 3: We exchange the code we got for an access token
 		// Then we can use the access token to do actions, limited to scopes we requested
-		token, err := conf.Exchange(oauth2.NoContext, r.FormValue("code"))
+		token, err := conf.Exchange(context.Background(), r.FormValue("code"))
 
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
As per this comment (https://github.com/ravener/discord-oauth2/pull/2#commitcomment-49174054), the deprecated function in question has been replaced with its functional alternative.

I've tested to ensure functionality, and the module functions as expected with the example script.

Thanks @Nezernite for raising this concern.